### PR TITLE
Create reporter with Stopped state

### DIFF
--- a/lib/rrdd_plugin.mli
+++ b/lib/rrdd_plugin.mli
@@ -43,7 +43,7 @@ module Reporter : sig
 		(** The reporter is running. *)
 		| Cancelled
 		(** A thread has cancelled the reporter. *)
-		| Stopped
+		| Stopped of [ `New | `Cancelled | `Failed of exn ]
 		(** The reporter has stopped. *)
 	(** The state of a reporter. *)
 


### PR DESCRIPTION
The reporter can then be set to running when the registration has completed.

This also extends the Stopped state to differentiate between a newly created
state, a cancelled (cleanly finished) state and a state that encountered an
error.

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>