### PR TITLE
jbuilder runtest: the test was failing to run

### DIFF
--- a/test/jbuild
+++ b/test/jbuild
@@ -8,4 +8,4 @@
 (alias
  ((name    runtest)
   (deps    (rrdp_dummy.exe))
-  (action  (run ${<}))))
+  (action  (run ${<} -help))))


### PR DESCRIPTION
jbuilder runtest was failing locally:

This is an example that doesn't seem to be meant to run during testing:
Fatal error: exception Unix.Unix_error(Unix.ENOENT, "connect", "")

Just test that the -help works for now.
