### PR TITLE
Factor out local reporter to allow avoiding the libxenctrl dependency

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,8 +1,9 @@
 (library
-  (name rrdd_plugin)
-  (public_name rrdd-plugin)
+  (name rrdd_plugin_base)
+  (public_name rrdd-plugin.base)
   (flags (:standard -bin-annot))
   (wrapped false)
+  (modules utils reporter)
   (libraries
     astring
     forkexec
@@ -12,9 +13,45 @@
     xapi-stdext-unix
     threads
     xapi-rrd
-    rrd-transport
+    rrd-transport.file
     xapi-idl.rrd
     xenstore_transport.unix
     xenstore.unix
+  )
+)
+
+(library
+  (name rrdd_plugin_local)
+  (public_name rrdd-plugin.local)
+  (flags (:standard -bin-annot))
+  (wrapped false)
+  (modules reporter_local)
+  (libraries
+    rrdd_plugin_base
+  )
+)
+
+(library
+  (name rrdd_plugin_interdomain)
+  (public_name rrdd-plugin.interdomain)
+  (flags (:standard -bin-annot))
+  (wrapped false)
+  (modules reporter_interdomain)
+  (libraries
+    rrdd_plugin_base
+    rrd-transport.page
+  )
+)
+
+(library
+  (name rrdd_plugin)
+  (public_name rrdd-plugin)
+  (flags (:standard -bin-annot))
+  (wrapped false)
+  (modules rrdd_plugin)
+  (libraries
+    rrdd_plugin_local
+    rrdd_plugin_interdomain
+    rrd-transport
   )
 )

--- a/lib/reporter.ml
+++ b/lib/reporter.ml
@@ -1,0 +1,171 @@
+(*
+ * Copyright (C) 2013 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Xapi_stdext_threads.Threadext
+open Xapi_stdext_unix
+
+(* This exception is setup to be raised on sigint by Process.initialise,
+ * and is used to cancel the synchronous function Reporter.start. *)
+exception Killed
+let killed = ref false (* CA-309024, Killed might escape *)
+
+module Xs = struct
+  module Xs = Xs_client_unix.Client(Xs_transport_unix_client)
+  include Xs
+
+  type xs_state = {
+    my_domid: int32;
+    root_path: string;
+    client: Xs.client;
+  }
+
+  let cached_xs_state = ref None
+
+  let cached_xs_state_m = Mutex.create ()
+
+  let get_xs_state () =
+    Mutex.execute cached_xs_state_m
+      (fun () ->
+         match !cached_xs_state with
+         | Some state -> state
+         | None ->
+           (* This creates a background thread, so must be done after daemonising. *)
+           let client = Xs.make () in
+           let my_domid =
+             Xs.immediate
+               client
+               (fun handle -> Xs.read handle "domid")
+             |> Int32.of_string
+           in
+           let root_path = Printf.sprintf "/local/domain/%ld/rrd" my_domid in
+           let state = {
+             my_domid;
+             root_path;
+             client
+           }
+           in cached_xs_state := Some state;
+           state)
+end
+
+(* Establish a XMLPRC interface with RRDD *)
+module RRDD = Rrd_client.Client
+
+type state =
+  | Running
+  | Cancelled
+  | Stopped of [ `New | `Cancelled | `Failed of exn ]
+
+type t = {
+  mutable state: state;
+  lock: Mutex.t;
+  condition: Condition.t;
+}
+
+let make () = {
+  state = Stopped `New;
+  lock = Mutex.create ();
+  condition = Condition.create ();
+}
+
+let choose_protocol = function
+  | Rrd_interface.V1 -> Rrd_protocol_v1.protocol
+  | Rrd_interface.V2 -> Rrd_protocol_v2.protocol
+
+let wait_until_next_reading
+    (module D : Debug.DEBUG)
+    ?(neg_shift=0.5)
+    ~uid
+    ~protocol ~overdue_count =
+  let next_reading =
+    RRDD.Plugin.Local.register uid Rrd.Five_Seconds protocol
+  in
+  let wait_time = next_reading -. neg_shift in
+  let wait_time = if wait_time < 0.1 then wait_time+.5. else wait_time in
+  (* overdue count - 0 if there is no overdue; +1 if there is overdue *)
+  if wait_time > 0. then begin
+    Thread.delay wait_time;
+    0
+  end
+  else begin
+    if (overdue_count > 1) then begin
+      (* if register returns negative more than once in a succession,
+         				the thread should get delayed till things are normal back again *)
+      let backoff_time = 2. ** ((float_of_int (overdue_count) -. 1.)) in
+      D.debug "rrdd says next reading is overdue, seems like rrdd is busy;
+				Backing off for %.1f seconds" backoff_time;
+      Thread.delay (backoff_time);
+    end
+    else D.debug "rrdd says next reading is overdue by %.1f seconds; not sleeping" (-.wait_time);
+    overdue_count + 1 (* overdue count incremented *)
+  end
+
+let loop (module D : Debug.DEBUG) ~reporter ~report ~cleanup =
+  let running = ref true in
+  begin match reporter with
+    | Some reporter ->
+      Mutex.execute reporter.lock (fun () ->
+          reporter.state <- Running)
+    | None -> ()
+  end;
+  while !running do
+    try
+      if !killed then raise Killed;
+      report ();
+      match reporter with
+      | Some reporter -> begin
+          (* Handle asynchronous cancellation. *)
+          Mutex.execute reporter.lock
+            (fun () ->
+               match reporter.state with
+               | Running -> ()
+               | Stopped _ -> ()
+               | Cancelled ->
+                 reporter.state <- Stopped `Cancelled;
+                 cleanup ();
+                 Condition.broadcast reporter.condition;
+                 running := false)
+        end
+      | None -> ()
+    with
+    | Sys.Break | Killed ->
+      (* Handle cancellation via signal handler. *)
+      D.info "received exception Killed or Break - cleaning up";
+      cleanup ();
+      running := false
+    | e ->
+      D.error
+        "Unexpected error %s, sleeping for 10 seconds..."
+        (Printexc.to_string e);
+      D.log_backtrace ();
+      Thread.delay 10.0
+  done;
+  D.info "leaving main loop"
+
+let get_state ~reporter =
+  Mutex.execute reporter.lock (fun () -> reporter.state)
+
+let cancel ~reporter =
+  Mutex.execute reporter.lock
+    (fun () ->
+       match reporter.state with
+       | Running -> begin
+           reporter.state <- Cancelled;
+           Condition.wait reporter.condition reporter.lock
+         end
+       | Cancelled -> Condition.wait reporter.condition reporter.lock
+       | Stopped _ -> ())
+
+let wait_until_stopped ~reporter =
+  Mutex.execute reporter.lock
+    (fun () -> Condition.wait reporter.condition reporter.lock)

--- a/lib/reporter_interdomain.ml
+++ b/lib/reporter_interdomain.ml
@@ -1,0 +1,60 @@
+(*
+ * Copyright (C) 2013 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Xapi_stdext_threads.Threadext
+open Xapi_stdext_unix
+open Reporter
+
+let start_interdomain
+    (module D : Debug.DEBUG)
+    ~reporter
+    ~uid
+    ~backend_domid
+    ~page_count
+    ~protocol
+    ~dss_f =
+  let id = Rrd_page_writer.({
+      backend_domid = backend_domid;
+      shared_page_count = page_count;
+    }) in
+  let shared_page_refs, writer =
+    Rrd_page_writer.create id (choose_protocol protocol)
+  in
+  let xs_state = Xs.get_xs_state () in
+  Xs.transaction xs_state.Xs.client (fun xs ->
+      Xs.write xs
+        (Printf.sprintf "%s/%s/grantrefs" xs_state.Xs.root_path uid)
+        (List.map string_of_int shared_page_refs |> String.concat ",");
+      Xs.write xs
+        (Printf.sprintf "%s/%s/protocol" xs_state.Xs.root_path uid)
+        (Rrd_interface.string_of_protocol protocol);
+      Xs.write xs
+        (Printf.sprintf "%s/%s/ready" xs_state.Xs.root_path uid)
+        "true");
+  let report () =
+    let payload = Rrd_protocol.({
+        timestamp = Utils.now ();
+        datasources = dss_f ();
+      }) in
+    writer.Rrd_writer_functor.write_payload payload;
+    Thread.delay 5.0
+  in
+  let cleanup () =
+    Xs.immediate xs_state.Xs.client (fun xs ->
+        Xs.write xs
+          (Printf.sprintf "%s/%s/shutdown" xs_state.Xs.root_path uid)
+          "true");
+    writer.Rrd_writer_functor.cleanup ()
+  in
+  loop (module D) ~reporter ~report ~cleanup

--- a/lib/reporter_local.ml
+++ b/lib/reporter_local.ml
@@ -1,0 +1,62 @@
+(*
+ * Copyright (C) 2013 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Xapi_stdext_threads.Threadext
+open Xapi_stdext_unix
+open Reporter
+
+let start_local (module D : Debug.DEBUG)
+    ~reporter
+    ~uid
+    ~neg_shift
+    ~page_count
+    ~protocol
+    ~dss_f =
+  try
+    let path = RRDD.Plugin.get_path uid in
+    D.info "Obtained path=%s\n" path;
+    let _ = Unixext.mkdir_safe (Filename.dirname path) 0o644 in
+    let id = Rrd_file_writer.({
+        path;
+        shared_page_count = page_count;
+      }) in
+    let _, writer =
+      Rrd_file_writer.create id (choose_protocol protocol)
+    in
+    let overdue_count = ref 0 in
+    let report () =
+      overdue_count := wait_until_next_reading
+          (module D)
+          ~neg_shift
+          ~uid
+          ~protocol
+          ~overdue_count:!overdue_count;
+      let payload = Rrd_protocol.({
+          timestamp = Utils.now ();
+          datasources = dss_f ();
+        }) in
+      writer.Rrd_writer_functor.write_payload payload;
+      Thread.delay 0.003
+    in
+    let cleanup () =
+      RRDD.Plugin.Local.deregister uid;
+      writer.Rrd_writer_functor.cleanup ()
+    in
+    loop (module D : Debug.DEBUG) ~reporter ~report ~cleanup
+  with exn ->
+  match reporter with
+  | Some reporter ->
+    Mutex.execute reporter.lock (fun () ->
+        reporter.state <- Stopped (`Failed exn))
+  | None -> raise exn

--- a/lib/rrdd_plugin.ml
+++ b/lib/rrdd_plugin.ml
@@ -12,14 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Xapi_stdext_threads.Threadext
-
 open Xapi_stdext_unix
-
-(* This exception is setup to be raised on sigint by Process.initialise,
- * and is used to cancel the synchronous function Reporter.start. *)
-exception Killed
-let killed = ref false (* CA-309024, Killed might escape *)
 
 let signal_name signum =
   let signals =
@@ -59,283 +52,15 @@ let signal_name signum =
     try Hashtbl.find signals signum with Not_found ->
       Printf.sprintf "unknown signal (%d)" signum
 
-module Utils = struct
-  let now () = Int64.of_float (Unix.gettimeofday ())
-
-  let cut str =
-    Astring.String.fields ~empty:false ~is_sep:(fun c -> c = ' ' || c = '\t') str
-
-  let list_directory_unsafe name =
-    let handle = Unix.opendir name in
-    let rec read_directory_contents acc handle =
-      try
-        let next_entry = Unix.readdir handle in
-        read_directory_contents (next_entry :: acc) handle
-      with End_of_file -> List.rev acc
-    in
-    Xapi_stdext_pervasives.Pervasiveext.finally
-      (fun () -> read_directory_contents [] handle)
-      (fun () -> Unix.closedir handle)
-
-  let list_directory_entries_unsafe dir =
-    let dirlist = list_directory_unsafe dir in
-    List.filter (fun x -> x <> "." && x <> "..") dirlist
-
-  let exec_cmd (module D : Debug.DEBUG) ~cmdstring ~(f : string -> 'a option) =
-    D.debug "Forking command %s" cmdstring;
-    (* create pipe for reading from the command's output *)
-    let (out_readme, out_writeme) = Unix.pipe () in
-    let cmd, args = match Astring.String.cuts ~empty:false ~sep:" " cmdstring with [] -> assert false | h::t -> h,t in
-    let pid = Forkhelpers.safe_close_and_exec None (Some out_writeme) None [] cmd args in
-    Unix.close out_writeme;
-    let in_channel = Unix.in_channel_of_descr out_readme in
-    let vals = ref [] in
-    let rec loop () =
-      let line = input_line in_channel in
-      let ret = f line in
-      begin
-        match ret with
-        | None -> ()
-        | Some v -> vals := v :: !vals
-      end;
-      loop ()
-    in
-    (try loop () with End_of_file -> ());
-    Unix.close out_readme;
-    let (pid, status) = Forkhelpers.waitpid pid in
-    begin
-      match status with
-      | Unix.WEXITED n   -> D.debug "Process %d exited normally with code %d" pid n
-      | Unix.WSIGNALED s -> D.debug "Process %d was killed by signal %d" pid s
-      | Unix.WSTOPPED s  -> D.debug "Process %d was stopped by signal %d" pid s
-    end;
-    List.rev !vals
-end
-
-(* Establish a XMLPRC interface with RRDD *)
-module RRDD = Rrd_client.Client
-
-module Xs = struct
-  module Xs = Xs_client_unix.Client(Xs_transport_unix_client)
-  include Xs
-
-  type xs_state = {
-    my_domid: int32;
-    root_path: string;
-    client: Xs.client;
-  }
-
-  let cached_xs_state = ref None
-
-  let cached_xs_state_m = Mutex.create ()
-
-  let get_xs_state () =
-    Mutex.execute cached_xs_state_m
-      (fun () ->
-         match !cached_xs_state with
-         | Some state -> state
-         | None ->
-           (* This creates a background thread, so must be done after daemonising. *)
-           let client = Xs.make () in
-           let my_domid =
-             Xs.immediate
-               client
-               (fun handle -> Xs.read handle "domid")
-             |> Int32.of_string
-           in
-           let root_path = Printf.sprintf "/local/domain/%ld/rrd" my_domid in
-           let state = {
-             my_domid;
-             root_path;
-             client
-           }
-           in cached_xs_state := Some state;
-           state)
-end
-
+module Utils = Utils
 module Reporter = struct
-  type state =
-    | Running
-    | Cancelled
-    | Stopped of [ `New | `Cancelled | `Failed of exn ]
-
+  include Reporter
+  include Reporter_local
+  include Reporter_interdomain
+  
   type target =
     | Local of int
     | Interdomain of (int * int)
-
-  type t = {
-    mutable state: state;
-    lock: Mutex.t;
-    condition: Condition.t;
-  }
-
-  let make () = {
-    state = Stopped `New;
-    lock = Mutex.create ();
-    condition = Condition.create ();
-  }
-
-  let choose_protocol = function
-    | Rrd_interface.V1 -> Rrd_protocol_v1.protocol
-    | Rrd_interface.V2 -> Rrd_protocol_v2.protocol
-
-  let wait_until_next_reading
-      (module D : Debug.DEBUG)
-      ?(neg_shift=0.5)
-      ~uid
-      ~protocol ~overdue_count =
-    let next_reading =
-      RRDD.Plugin.Local.register uid Rrd.Five_Seconds protocol
-    in
-    let wait_time = next_reading -. neg_shift in
-    let wait_time = if wait_time < 0.1 then wait_time+.5. else wait_time in
-    (* overdue count - 0 if there is no overdue; +1 if there is overdue *)
-    if wait_time > 0. then begin
-      Thread.delay wait_time;
-      0
-    end
-    else begin
-      if (overdue_count > 1) then begin
-        (* if register returns negative more than once in a succession,
-           				the thread should get delayed till things are normal back again *)
-        let backoff_time = 2. ** ((float_of_int (overdue_count) -. 1.)) in
-        D.debug "rrdd says next reading is overdue, seems like rrdd is busy;
-					Backing off for %.1f seconds" backoff_time;
-        Thread.delay (backoff_time);
-      end
-      else D.debug "rrdd says next reading is overdue by %.1f seconds; not sleeping" (-.wait_time);
-      overdue_count + 1 (* overdue count incremented *)
-    end
-
-  let loop (module D : Debug.DEBUG) ~reporter ~report ~cleanup =
-    let running = ref true in
-    begin match reporter with
-      | Some reporter ->
-        Mutex.execute reporter.lock (fun () ->
-            reporter.state <- Running)
-      | None -> ()
-    end;
-    while !running do
-      try
-        if !killed then raise Killed;
-        report ();
-        match reporter with
-        | Some reporter -> begin
-            (* Handle asynchronous cancellation. *)
-            Mutex.execute reporter.lock
-              (fun () ->
-                 match reporter.state with
-                 | Running -> ()
-                 | Stopped _ -> ()
-                 | Cancelled ->
-                   reporter.state <- Stopped `Cancelled;
-                   cleanup ();
-                   Condition.broadcast reporter.condition;
-                   running := false)
-          end
-        | None -> ()
-      with
-      | Sys.Break | Killed ->
-        (* Handle cancellation via signal handler. *)
-        D.info "received exception Killed or Break - cleaning up";
-        cleanup ();
-        running := false
-      | e ->
-        D.error
-          "Unexpected error %s, sleeping for 10 seconds..."
-          (Printexc.to_string e);
-        D.log_backtrace ();
-        Thread.delay 10.0
-    done;
-    D.info "leaving main loop"
-
-  let start_local (module D : Debug.DEBUG)
-      ~reporter
-      ~uid
-      ~neg_shift
-      ~page_count
-      ~protocol
-      ~dss_f =
-    try
-      let path = RRDD.Plugin.get_path uid in
-      D.info "Obtained path=%s\n" path;
-      let _ = Unixext.mkdir_safe (Filename.dirname path) 0o644 in
-      let id = Rrd_writer.({
-          path;
-          shared_page_count = page_count;
-        }) in
-      let _, writer =
-        Rrd_writer.FileWriter.create id (choose_protocol protocol)
-      in
-      let overdue_count = ref 0 in
-      let report () =
-        overdue_count := wait_until_next_reading
-            (module D)
-            ~neg_shift
-            ~uid
-            ~protocol
-            ~overdue_count:!overdue_count;
-        let payload = Rrd_protocol.({
-            timestamp = Utils.now ();
-            datasources = dss_f ();
-          }) in
-        writer.Rrd_writer.write_payload payload;
-        Thread.delay 0.003
-      in
-      let cleanup () =
-        RRDD.Plugin.Local.deregister uid;
-        writer.Rrd_writer.cleanup ()
-      in
-      loop (module D : Debug.DEBUG) ~reporter ~report ~cleanup
-    with exn ->
-    match reporter with
-    | Some reporter ->
-      Mutex.execute reporter.lock (fun () ->
-          reporter.state <- Stopped (`Failed exn))
-    | None -> raise exn
-
-  let start_interdomain
-      (module D : Debug.DEBUG)
-      ~reporter
-      ~uid
-      ~backend_domid
-      ~page_count
-      ~protocol
-      ~dss_f =
-    let id = Rrd_writer.({
-        backend_domid = backend_domid;
-        shared_page_count = page_count;
-      }) in
-    let shared_page_refs, writer =
-      Rrd_writer.PageWriter.create id (choose_protocol protocol)
-    in
-    let xs_state = Xs.get_xs_state () in
-    Xs.transaction xs_state.Xs.client (fun xs ->
-        Xs.write xs
-          (Printf.sprintf "%s/%s/grantrefs" xs_state.Xs.root_path uid)
-          (List.map string_of_int shared_page_refs |> String.concat ",");
-        Xs.write xs
-          (Printf.sprintf "%s/%s/protocol" xs_state.Xs.root_path uid)
-          (Rrd_interface.string_of_protocol protocol);
-        Xs.write xs
-          (Printf.sprintf "%s/%s/ready" xs_state.Xs.root_path uid)
-          "true");
-    let report () =
-      let payload = Rrd_protocol.({
-          timestamp = Utils.now ();
-          datasources = dss_f ();
-        }) in
-      writer.Rrd_writer.write_payload payload;
-      Thread.delay 5.0
-    in
-    let cleanup () =
-      Xs.immediate xs_state.Xs.client (fun xs ->
-          Xs.write xs
-            (Printf.sprintf "%s/%s/shutdown" xs_state.Xs.root_path uid)
-            "true");
-      writer.Rrd_writer.cleanup ()
-    in
-    loop (module D) ~reporter ~report ~cleanup
 
   let start (module D : Debug.DEBUG) ~uid ~neg_shift ~target ~protocol ~dss_f =
     match target with
@@ -380,24 +105,6 @@ module Reporter = struct
         ()
     in
     reporter
-
-  let get_state ~reporter =
-    Mutex.execute reporter.lock (fun () -> reporter.state)
-
-  let cancel ~reporter =
-    Mutex.execute reporter.lock
-      (fun () ->
-         match reporter.state with
-         | Running -> begin
-             reporter.state <- Cancelled;
-             Condition.wait reporter.condition reporter.lock
-           end
-         | Cancelled -> Condition.wait reporter.condition reporter.lock
-         | Stopped _ -> ())
-
-  let wait_until_stopped ~reporter =
-    Mutex.execute reporter.lock
-      (fun () -> Condition.wait reporter.condition reporter.lock)
 end
 
 module Process = functor (N : (sig val name : string end)) -> struct
@@ -407,8 +114,8 @@ module Process = functor (N : (sig val name : string end)) -> struct
     D.info "Received signal %s: deregistering plugin %s..."
       (signal_name signum) N.name;
     D.info "Raising exception Killed in %s" __LOC__;
-    killed := true;
-    raise Killed
+    Reporter.killed := true;
+    raise Reporter.Killed
 
   let initialise () =
     (* CA-92551, CA-97938: Use syslog's local0 facility *)

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -1,0 +1,64 @@
+(*
+ * Copyright (C) 2013 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+let now () = Int64.of_float (Unix.gettimeofday ())
+
+let cut str =
+  Astring.String.fields ~empty:false ~is_sep:(fun c -> c = ' ' || c = '\t') str
+
+let list_directory_unsafe name =
+  let handle = Unix.opendir name in
+  let rec read_directory_contents acc handle =
+    try
+      let next_entry = Unix.readdir handle in
+      read_directory_contents (next_entry :: acc) handle
+    with End_of_file -> List.rev acc
+  in
+  Xapi_stdext_pervasives.Pervasiveext.finally
+    (fun () -> read_directory_contents [] handle)
+    (fun () -> Unix.closedir handle)
+
+let list_directory_entries_unsafe dir =
+  let dirlist = list_directory_unsafe dir in
+  List.filter (fun x -> x <> "." && x <> "..") dirlist
+
+let exec_cmd (module D : Debug.DEBUG) ~cmdstring ~(f : string -> 'a option) =
+  D.debug "Forking command %s" cmdstring;
+  (* create pipe for reading from the command's output *)
+  let (out_readme, out_writeme) = Unix.pipe () in
+  let cmd, args = match Astring.String.cuts ~empty:false ~sep:" " cmdstring with [] -> assert false | h::t -> h,t in
+  let pid = Forkhelpers.safe_close_and_exec None (Some out_writeme) None [] cmd args in
+  Unix.close out_writeme;
+  let in_channel = Unix.in_channel_of_descr out_readme in
+  let vals = ref [] in
+  let rec loop () =
+    let line = input_line in_channel in
+    let ret = f line in
+    begin
+      match ret with
+      | None -> ()
+      | Some v -> vals := v :: !vals
+    end;
+    loop ()
+  in
+  (try loop () with End_of_file -> ());
+  Unix.close out_readme;
+  let (pid, status) = Forkhelpers.waitpid pid in
+  begin
+    match status with
+    | Unix.WEXITED n   -> D.debug "Process %d exited normally with code %d" pid n
+    | Unix.WSIGNALED s -> D.debug "Process %d was killed by signal %d" pid s
+    | Unix.WSTOPPED s  -> D.debug "Process %d was stopped by signal %d" pid s
+  end;
+  List.rev !vals

--- a/lib/utils.mli
+++ b/lib/utils.mli
@@ -1,0 +1,32 @@
+(*
+ * Copyright (C) 2013 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(** Utility functions useful for rrdd plugins. *)
+  val now : unit -> int64
+  (** Return the current unix epoch as an int64. *)
+
+  val cut : string -> string list
+  (** Split a string into a list of strings as separated by spaces and/or
+      	    tabs. *)
+
+  val list_directory_unsafe : string -> string list
+  (** List the contents of a directory, including . and .. *)
+
+  val list_directory_entries_unsafe : string -> string list
+  (** List the contents of a directory, not including . and .. *)
+
+  val exec_cmd : (module Debug.DEBUG) -> cmdstring:string -> f:(string -> 'a option) -> 'a list
+  (** [exec_cmd cmd f] executes [cmd], applies [f] on each of the lines which
+      	    [cmd] outputs on stdout, and returns a list of resulting values for which
+      	    applying [f] returns [Some value]. *)

--- a/rrdd-plugin.opam
+++ b/rrdd-plugin.opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml"
   "dune" {build & >= "1.0+beta10"}
   "astring"
-  "rpc"
+  "rpclib"
   "xapi-forkexecd"
   "xapi-stdext-pervasives"
   "xapi-stdext-std"


### PR DESCRIPTION
This builds upon https://github.com/xapi-project/rrd-transport/pull/57, and is a similar refactor: no functional change, but adding the ability to avoid the libxenctrl dependency.